### PR TITLE
Give option for form choices to be different to the default choices

### DIFF
--- a/src/Filter/Choices.php
+++ b/src/Filter/Choices.php
@@ -8,6 +8,7 @@ class Choices implements FilterInterface
 	private $_label;
 	private $_choices;
 	private $_multichoice;
+	private $_formChoices = null;
 
 	/**
 	 * Constructor.
@@ -32,7 +33,12 @@ class Choices implements FilterInterface
 	 */
 	public function getForm()
 	{
-		return new Form\Choices($this->_label, $this->_choices, $this->_multichoice, $this->_filterName);
+		$choices = $this->_formChoices === null
+			? array_combine($this->_choices, $this->_choices)
+			: $this->_formChoices
+		;
+
+		return new Form\Choices($this->_label, $choices, $this->_multichoice, $this->_filterName);
 	}
 
 	/**
@@ -87,4 +93,8 @@ class Choices implements FilterInterface
 		return $this->_choices = $choice;
 	}
 
+	public function setFormChoices($choices)
+	{
+		return $this->_formChoices = $choices;
+	}
 }

--- a/src/Filter/Choices.php
+++ b/src/Filter/Choices.php
@@ -95,6 +95,8 @@ class Choices implements FilterInterface
 
 	public function setFormChoices($choices)
 	{
-		return $this->_formChoices = $choices;
+		$this->_formChoices = $choices;
+
+		return $this;
 	}
 }

--- a/src/Filter/Form/Choices.php
+++ b/src/Filter/Form/Choices.php
@@ -43,10 +43,20 @@ class Choices extends AbstractType
 	 */
 	public function buildForm(FormBuilderInterface $builder, array $options)
 	{
+		$choices = $this->_isAssocArray($this->_choices)
+			? $this->_choices
+			: array_combine($this->_choices, $this->_choices)
+		;
+
 		$builder->add('choices', 'choice', [
 			'label'    => $this->_label,
-			'choices'  => array_combine($this->_choices, $this->_choices),
+			'choices'  => $choices,
 			'multiple' => $this->_multichoice
 		]);
+	}
+
+	private function _isAssocArray($array)
+	{
+		return array_keys($arr) !== range(0, count($arr) - 1);
 	}
 }

--- a/src/Filter/Form/Choices.php
+++ b/src/Filter/Form/Choices.php
@@ -57,6 +57,6 @@ class Choices extends AbstractType
 
 	private function _isAssocArray($array)
 	{
-		return array_keys($arr) !== range(0, count($arr) - 1);
+		return array_keys($array) !== range(0, count($array) - 1);
 	}
 }


### PR DESCRIPTION
Will use current behaviour unless _formChoices is set. If that's the case, it will use the _formChoices variable as the form's choices.

So to get a choice filter with no default options you can call:
```php
// create filter 
$choice = new Filter\Choices('name', null, []);
// set form choices
$choice->setFormChoices(
    [
        'uk' => 'United Kingdom',
        'ca' => 'Canada',
        'us' => 'United States',
    ]
);
```