### PR TITLE
Modifying filters

### DIFF
--- a/src/Filter/Choices.php
+++ b/src/Filter/Choices.php
@@ -8,6 +8,7 @@ class Choices implements FilterInterface
 	private $_label;
 	private $_choices;
 	private $_multichoice;
+	private $_formChoices = null;
 
 	/**
 	 * Constructor.
@@ -32,7 +33,12 @@ class Choices implements FilterInterface
 	 */
 	public function getForm()
 	{
-		return new Form\Choices($this->_label, $this->_choices, $this->_multichoice, $this->_filterName);
+		$choices = $this->_formChoices === null
+			? array_combine($this->_choices, $this->_choices)
+			: $this->_formChoices
+		;
+
+		return new Form\Choices($this->_label, $choices, $this->_multichoice, $this->_filterName);
 	}
 
 	/**
@@ -87,4 +93,8 @@ class Choices implements FilterInterface
 		return $this->_choices = $choice;
 	}
 
+	public function setFormChoices($choices)
+	{
+		return $this->_formChoices = $choices;
+	}
 }

--- a/src/Filter/Choices.php
+++ b/src/Filter/Choices.php
@@ -95,6 +95,8 @@ class Choices implements FilterInterface
 
 	public function setFormChoices($choices)
 	{
-		return $this->_formChoices = $choices;
+		$this->_formChoices = $choices;
+
+		return $this;
 	}
 }

--- a/src/Filter/Choices.php
+++ b/src/Filter/Choices.php
@@ -84,15 +84,25 @@ class Choices implements FilterInterface
 	/**
 	 * Sets the choices to filter
 	 *
-	 * @param  $choices description
+	 * @param  $choices array | mixed
 	 *
 	 * @return String the choices
 	*/
-	public function setChoices($choice)
+	public function setChoices($choices)
 	{
-		return $this->_choices = $choice;
+		return $this->_choices = $choices;
 	}
 
+	/**
+	 * Set the choices as they will appear on the form. In versions 2.0.0 and earlier the forms would populate with
+	 * choices set in `$_choices`, but this causes problems as this property is also used for storing form data
+	 * values, so should this method should be used instead. If this method is not used the filter will default to
+	 * its original behaviour.
+	 *
+	 * @param $choices
+	 *
+	 * @return $this
+	 */
 	public function setFormChoices($choices)
 	{
 		$this->_formChoices = $choices;

--- a/src/Filter/Form/Choices.php
+++ b/src/Filter/Form/Choices.php
@@ -43,10 +43,20 @@ class Choices extends AbstractType
 	 */
 	public function buildForm(FormBuilderInterface $builder, array $options)
 	{
+		$choices = $this->_isAssocArray($this->_choices)
+			? $this->_choices
+			: array_combine($this->_choices, $this->_choices)
+		;
+
 		$builder->add('choices', 'choice', [
 			'label'    => $this->_label,
-			'choices'  => array_combine($this->_choices, $this->_choices),
+			'choices'  => $choices,
 			'multiple' => $this->_multichoice
 		]);
+	}
+
+	private function _isAssocArray($array)
+	{
+		return array_keys($arr) !== range(0, count($arr) - 1);
 	}
 }

--- a/src/Filter/Form/Choices.php
+++ b/src/Filter/Form/Choices.php
@@ -57,6 +57,6 @@ class Choices extends AbstractType
 
 	private function _isAssocArray($array)
 	{
-		return array_keys($arr) !== range(0, count($arr) - 1);
+		return array_keys($array) !== range(0, count($array) - 1);
 	}
 }

--- a/src/Filter/ModifyQueryInterface.php
+++ b/src/Filter/ModifyQueryInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Message\Mothership\Report\Filter;
+
+use Message\Cog\DB\QueryBuilder;
+
+/**
+ * Interface ModifyQueryInterface
+ * @package Message\Mothership\Report\Report\AppendQuery
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ *
+ * Interface for modifying query rather than uniting another query with it
+ */
+interface ModifyQueryInterface
+{
+	/**
+	 * @param QueryBuilder $queryBuilder
+	 *
+	 * Apply a modification to the main report query, e.g. adding a new where statement
+	 */
+	public function apply(QueryBuilder $queryBuilder);
+}


### PR DESCRIPTION
This PR allows greater flexibility with filtering in reports. It adds an `ModifyQueryInterface` interface for altering the query builders, e.g. by adding joins and where statements, without needing to perform a union.

It also adds a `Choices::setFormChoices()` method to help to decouple the choices that appear in the form field and the data that is submitted via the form field