### PR TITLE
Allow DateRange filter to use `date` instead of `datetime` form fields

### DIFF
--- a/src/Filter/DateRange.php
+++ b/src/Filter/DateRange.php
@@ -44,7 +44,9 @@ class DateRange implements FilterInterface
 	 * - 'date'
 	 * - 'datetime'
 	 *
-	 * @param $type
+	 * @param string $type
+	 * @throws \InvalidArgumentException   Throws exception if $type is not a string
+	 * @throws \LogicException             Throws exception if $type is not listed as valid
 	 */
 	public function setFormType($type)
 	{
@@ -54,7 +56,7 @@ class DateRange implements FilterInterface
 		}
 
 		if (!in_array($type, $this->_validFormTypes)) {
-			throw new \InvalidArgumentException('`' . $type . '` is not a valid form type for this filter, allowed options: ' . implode(', ', $this->_validFormTypes));
+			throw new \LogicException('`' . $type . '` is not a valid form type for this filter, allowed options: ' . implode(', ', $this->_validFormTypes));
 		}
 
 		$this->_type = $type;
@@ -109,7 +111,7 @@ class DateRange implements FilterInterface
 	/**
 	 * Sets the date to filter from
 	 *
-	 *  @param \DateTime $from
+	 * @param \DateTime $from
 	 *
 	 * @return \DateTime the start date
 	 */

--- a/src/Filter/DateRange.php
+++ b/src/Filter/DateRange.php
@@ -4,8 +4,28 @@ namespace Message\Mothership\Report\Filter;
 
 class DateRange implements FilterInterface
 {
+	/**
+	 * @var \DateTime | null
+	 */
 	private $_from;
+
+	/**
+	 * @var \DateTime | null
+	 */
 	private $_to;
+
+	/**
+	 * @var string | null
+	 */
+	private $_type;
+
+	/**
+	 * @var array
+	 */
+	private $_validFormTypes = [
+		'date',
+		'datetime'
+	];
 
 	/**
 	 * Constructor.
@@ -20,13 +40,40 @@ class DateRange implements FilterInterface
 	}
 
 	/**
+	 * Set which type of form fields the DateRange form should use. Available options:
+	 * - 'date'
+	 * - 'datetime'
+	 *
+	 * @param $type
+	 */
+	public function setFormType($type)
+	{
+		if (!is_string($type)) {
+			$varType = (gettype($type) === 'object') ? get_class($type) : gettype($type);
+			throw new \InvalidArgumentException('Tyoe must be a string, ' . $varType . ' given');
+		}
+
+		if (!in_array($type, $this->_validFormTypes)) {
+			throw new \InvalidArgumentException('`' . $type . '` is not a valid form type for this filter, allowed options: ' . implode(', ', $this->_validFormTypes));
+		}
+
+		$this->_type = $type;
+	}
+
+	/**
 	 * Gets the form for the filter.
 	 *
 	 * @return Form\DateRange the form
 	 */
 	public function getForm()
 	{
-		return new Form\DateRange($this->getStartDate(), $this->getEndDate());
+		$form = new Form\DateRange($this->getStartDate(), $this->getEndDate());
+
+		if (null !== $this->_type) {
+			$form->setType($this->_type);
+		}
+
+		return $form;
 	}
 
 	/**
@@ -62,6 +109,8 @@ class DateRange implements FilterInterface
 	/**
 	 * Sets the date to filter from
 	 *
+	 *  @param \DateTime $from
+	 *
 	 * @return \DateTime the start date
 	 */
 	public function setStartDate($from)
@@ -71,6 +120,8 @@ class DateRange implements FilterInterface
 
 	/**
 	 * Sets the date to filter to
+	 *
+	 * @param \DateTime $to
 	 *
 	 * @return \DateTime the end date
 	 */

--- a/src/Filter/Form/DateRange.php
+++ b/src/Filter/Form/DateRange.php
@@ -7,8 +7,28 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class DateRange extends AbstractType
 {
+	/**
+	 * @var \DateTime | null
+	 */
 	private $_from;
+
+	/**
+	 * @var \DateTime | null
+	 */
 	private $_to;
+
+	/**
+	 * @var string
+	 */
+	private $_type = 'datetime';
+
+	/**
+	 * @var array
+	 */
+	private $_validFormTypes = [
+		'date',
+		'datetime'
+	];
 
 	/**
 	 * Constructor.
@@ -33,15 +53,36 @@ class DateRange extends AbstractType
 	}
 
 	/**
+	 * Set which type of form to use to create the date range form, available options:
+	 * - 'date'
+	 * - 'datetime'
+	 *
+	 * @param $type
+	 */
+	public function setType($type)
+	{
+		if (!is_string($type)) {
+			$varType = (gettype($type) === 'object') ? get_class($type) : gettype($type);
+			throw new \InvalidArgumentException('Type must be a string, ' . $varType . ' given');
+		}
+
+		if (!in_array($type, $this->_validFormTypes)) {
+			throw new \InvalidArgumentException('`' . $type . '` is not a valid form type for this filter, allowed options: ' . implode(', ', $this->_validFormTypes));
+		}
+
+		$this->_type = $type;
+	}
+
+	/**
 	 * {@inheritdoc}
 	 */
 	public function buildForm(FormBuilderInterface $builder, array $options)
 	{
-		$builder->add('startdate', 'datetime', [
+		$builder->add('startdate', $this->_type, [
 			'label' => 'From',
 			'data'  => $this->_from ?: null,
 		]);
-		$builder->add('enddate', 'datetime', [
+		$builder->add('enddate', $this->_type, [
 			'label' => 'To',
 			'data'  => $this->_to ?: null,
 		]);

--- a/src/Filter/Form/DateRange.php
+++ b/src/Filter/Form/DateRange.php
@@ -58,6 +58,8 @@ class DateRange extends AbstractType
 	 * - 'datetime'
 	 *
 	 * @param $type
+	 * @throws \InvalidArgumentException   Throws exception if $type is not a string
+	 * @throws \LogicException             Throws exception if $type is not listed as valid
 	 */
 	public function setType($type)
 	{
@@ -67,7 +69,7 @@ class DateRange extends AbstractType
 		}
 
 		if (!in_array($type, $this->_validFormTypes)) {
-			throw new \InvalidArgumentException('`' . $type . '` is not a valid form type for this filter, allowed options: ' . implode(', ', $this->_validFormTypes));
+			throw new \LogicException('`' . $type . '` is not a valid form type for this filter, allowed options: ' . implode(', ', $this->_validFormTypes));
 		}
 
 		$this->_type = $type;


### PR DESCRIPTION
This PR makes it so that the DateRange filter can use `date` fields instead of `datetime`.

To toggle this, call the `setFormType()` method on the filter. You can also set it directly on the DateRange form by calling `setType()`.

Both methods are more or less the same, you can only set 'date' or 'datetime'